### PR TITLE
fix: add input validation to prevent zero income or loan amount submission

### DIFF
--- a/ai-credit-intelligence-engine/application.py
+++ b/ai-credit-intelligence-engine/application.py
@@ -681,6 +681,13 @@ with col_btn:
 # Prediction
 # -----------------------------------
 if run:
+    # -----------------------------------
+    # Input Validation
+    # -----------------------------------
+    if applicant_income == 0 or loan_amount == 0:
+        st.error("⚠ Income and Loan Amount must be greater than zero.")
+        st.stop()
+
     import time
     from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
     from reportlab.lib import colors


### PR DESCRIPTION
Adds input validation before the prediction model runs. Previously, submitting with Applicant Income = 0 or Loan Amount = 0 would silently pass invalid data to the model and return unreliable results.

**Changes**

Added a validation check right after the "Analyse" button is clicked
If either applicant_income or loan_amount is zero, an error message is shown and st.stop() is called — the model never executes


**Error message shown to user**
⚠ Income and Loan Amount must be greater than zero.

