### PR TITLE
fix: correct confidence score label and fix currency encoding in PDF report

### DIFF
--- a/ai-credit-intelligence-engine/application.py
+++ b/ai-credit-intelligence-engine/application.py
@@ -798,7 +798,7 @@ if run:
 
         # Income check
         if total_income < 25000:
-            reasons.append("Total household income is below the recommended threshold (₹25,000).")
+            reasons.append("Total household income is below the recommended threshold (Rs25,000).")
 
         # EMI ratio check
         if emi_ratio > 0.5:
@@ -862,13 +862,12 @@ if run:
     # Financial Table
     content.append(Paragraph("Financial Summary", section_style))
     content.append(Spacer(1, 10))
-
     table = Table([
         ["Metric", "Value"],
-        ["Total Income", f"₹ {total_income:,}"],
-        ["Loan Amount", f"₹ {loan_amount:,}"],
+        ["Total Income", f"Rs {total_income:,}"],
+        ["Loan Amount", f"Rs {loan_amount:,}"],
         ["Loan Term", f"{loan_term} months"],
-        ["EMI", f"₹ {round(emi,2)}"]
+        ["EMI", f"Rs {round(emi,2)}"]
     ])
 
     table.setStyle(TableStyle([
@@ -907,7 +906,10 @@ if run:
 
     content.append(Paragraph(decision_text, decision_style))
     content.append(Spacer(1, 10))
-    content.append(Paragraph(f"Confidence: {round(approval_prob,2)}%", styles["Normal"]))
+    #Updated confidence and rejection label 
+    confidence = round(approval_prob, 2) if prediction[0] == 1 else round(100 - approval_prob, 2)
+    label = "Approval Confidence" if prediction[0] == 1 else "Rejection Confidence"
+    content.append(Paragraph(f"{label}: {confidence}%", styles["Normal"]))
     content.append(Spacer(1, 20))
 
     # -------------------------------

--- a/ai-credit-intelligence-engine/application.py
+++ b/ai-credit-intelligence-engine/application.py
@@ -798,7 +798,7 @@ if run:
 
         # Income check
         if total_income < 25000:
-            reasons.append("Total household income is below the recommended threshold (Rs25,000).")
+            reasons.append("Total household income is below the recommended threshold (Rs.25,000).")
 
         # EMI ratio check
         if emi_ratio > 0.5:
@@ -864,10 +864,10 @@ if run:
     content.append(Spacer(1, 10))
     table = Table([
         ["Metric", "Value"],
-        ["Total Income", f"Rs {total_income:,}"],
-        ["Loan Amount", f"Rs {loan_amount:,}"],
+        ["Total Income", f"Rs. {total_income:,}"],
+        ["Loan Amount", f"Rs. {loan_amount:,}"],
         ["Loan Term", f"{loan_term} months"],
-        ["EMI", f"Rs {round(emi,2)}"]
+        ["EMI", f"Rs. {round(emi,2)}"]
     ])
 
     table.setStyle(TableStyle([


### PR DESCRIPTION
## What does this PR do?
Fixes two display bugs in the generated PDF reports — incorrect 
confidence score display and broken currency symbol rendering.

## Problems Fixed

**1. Confidence score showing 0.0% in PDF**
The PDF hardcoded approval_prob for both approved and rejected 
cases. Since approval_prob represents probability of approval, 
it is ~0% for rejections — causing the PDF to always show 0.0% 
even when the UI correctly displayed 100% rejection confidence.

**2. ₹ symbol rendering as ■ in PDF**
ReportLab's default Helvetica font does not support Unicode 
characters. The ₹ symbol was causing all currency values to 
render as black squares (■), making reports unreadable and 
unprofessional.

## Fixes Applied

**Confidence:**
Added a conditional to mirror the logic already present in the 
UI — approvals use approval_prob, rejections use 
(100 - approval_prob). 
Also improved label clarity from the 
generic "Confidence" to "Approval Confidence" or 
"Rejection Confidence" so non-technical users immediately 
understand what the percentage refers to.

**Currency:**
Replaced ₹ with Rs. in all PDF generation code. Streamlit UI 
references are intentionally unchanged as browsers handle 
Unicode natively — this fix is deliberately scoped to the 
PDF section only.

## Changes
- application.py: confidence label logic updated (2 lines)
- application.py: 4 instances of ₹ → Rs. in PDF section only

## Code Change

Before:
content.append(Paragraph(f"Confidence: {round(approval_prob,2)}%"))

After:
confidence = round(approval_prob, 2) if prediction[0] == 1 else round(100 - approval_prob, 2)
label = "Approval Confidence" if prediction[0] == 1 else "Rejection Confidence"
content.append(Paragraph(f"{label}: {confidence}%", styles["Normal"]))

## Testing
Tested locally with multiple input profiles including:
- Clear rejection case (credit score 450, high dependents)
- Borderline case (credit score 586, strong collateral)
- Strong approval profile (credit score 750, healthy income)

All cases now show correct confidence value and Rs. renders 
correctly throughout the PDF.

## Screenshots
Before changes in code :
<img width="290" height="283" alt="before-report" src="https://github.com/user-attachments/assets/2314102d-f8cd-4e8b-8cdb-05e0042a29f3" />

After changes in code:
<img width="423" height="420" alt="after report" src="https://github.com/user-attachments/assets/ddba6d8d-c594-4b50-b7e3-2edb4a37ff30" />

Resolves #51 