### PR TITLE
fix: correct PDF confidence logic and currency rendering (#51)

### DIFF
--- a/ai-credit-intelligence-engine/application.py
+++ b/ai-credit-intelligence-engine/application.py
@@ -800,17 +800,17 @@ if run:
     decision_text = "APPROVED" if prediction[0] == 1 else "REJECTED"
 
     if prediction[0] == 1:
-        st.success(f"✓ Loan Approved (Confidence: {round(approval_prob,2)}%)")
+        st.success(f"✓ Loan Approved (Approval Confidence: {round(approval_prob,2)}%)")
 
     else:
-        st.error(f"✕ Loan Rejected (Confidence: {round(100-approval_prob,2)}%)")
+        st.error(f"✕ Loan Rejected (Rejection Confidence: {round(100-approval_prob,2)}%)")
 
         # ---- Rejection Reason Logic ----
         reasons = []
 
         # Income check
         if total_income < 25000:
-            reasons.append("Total household income is below the recommended threshold (₹25,000).")
+            reasons.append("Total household income is below the recommended threshold (Rs. 25,000).")
 
         # EMI ratio check
         if emi_ratio > 0.5:
@@ -877,10 +877,10 @@ if run:
 
     table = Table([
         ["Metric", "Value"],
-        ["Total Income", f"₹ {total_income:,}"],
-        ["Loan Amount", f"₹ {loan_amount:,}"],
+        ["Total Income", f"Rs. {total_income:,}"],
+        ["Loan Amount", f"Rs. {loan_amount:,}"],
         ["Loan Term", f"{loan_term} months"],
-        ["EMI", f"₹ {round(emi,2)}"]
+        ["EMI", f"Rs. {round(emi,2)}"]
     ])
 
     table.setStyle(TableStyle([
@@ -919,7 +919,10 @@ if run:
 
     content.append(Paragraph(decision_text, decision_style))
     content.append(Spacer(1, 10))
-    content.append(Paragraph(f"Confidence: {round(approval_prob,2)}%", styles["Normal"]))
+    if prediction[0] == 1:
+        content.append(Paragraph(f"Approval Confidence: {round(approval_prob,2)}%", styles["Normal"]))
+    else:
+        content.append(Paragraph(f"Rejection Confidence: {round(100-approval_prob,2)}%", styles["Normal"]))
     content.append(Spacer(1, 20))
 
     # -------------------------------


### PR DESCRIPTION
Resolves #51

### Bug Description
This PR addresses two specific display bugs found in the generated PDF reports and aligns the logic with the Streamlit UI.

### Fixes Implemented
1. **Accurate Confidence Scoring**: Updated the PDF generation logic to correctly calculate and display rejection confidence (`100 - approval_prob`). Previously, it incorrectly defaulted to `~0.0%` for all rejected loans.
2. **Clearer UX Labels**: Replaced the ambiguous "Confidence" label with explicit `Approval Confidence` and `Rejection Confidence` labels in both the PDF report and the Streamlit UI.
3. **Currency Symbol Rendering**: Replaced the unsupported `₹` symbol with `Rs.` within the PDF's Financial Summary table and dynamic rejection reasons. This prevents the `₹` symbol from rendering as a black square (`■`) due to ReportLab font limitations.

### Steps to Verify
- Submit a rejected loan application and download the PDF.
- The PDF will now correctly state `Rejection Confidence: 100%` (or similar).
- Currency amounts in the PDF now correctly display as `Rs. 1,50,000` without any rendering glitches.
